### PR TITLE
Included explicit requirements and fixed bug on (at least) PyTorch > 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,71 @@ IEEE Journal of Biomedical and Health Informatics (IEEE JBHI), 2021 ([DOI](http:
 * ACS convolution enables **2D-to-3D transfer learning**, which consistently provides significant performance boost in our experiments.
 * Even without pretraining, ACS convolution is **comparable to or even better than** 3D convolution, with **smaller model size** and **less computation**.
 
+## Requirements
+
+### Base requirements
+
+The bare minimum to run the ACSConv package.
+
+```python
+torch>=1.8.1
+torchvision>=0.9.0
+```
+
+You can install them either manually or through the command:
+
+``` bash
+pip install -r requirements.txt
+```
+
+### Experimental requirements
+
+All libraries needed to run the included experiments (base requirements included).
+
+```python
+fire==0.4.0
+jupyterlab>=3.0.12
+matplotlib==3.3.4
+pandas==1.1.3
+torch==1.8.0
+torchvision==0.9.0
+tqdm==4.59.0
+scikit-image==0.17.2
+scikit-learn==0.24.1
+scipy==1.5.2
+tensorboardx==2.1
+```
+
+You can install them either manually or through the command:
+
+``` bash
+pip install -r experimental_requirements.txt
+```
+
+## Package Installation
+
+If you want to use this class, you have two options:
+
+A) Simply copy and paste it in your project;
+
+B) Or install it through `pip` following the command bellow:
+
+``` bash
+pip install git+git://github.com/M3DV/ACSConv.git#egg=ACSConv
+```
+
+> **Note 1**: As noted by [David Winterbottom](https://codeinthehole.com/tips/using-pip-and-requirementstxt-to-install-from-the-head-of-a-github-branch/), if you freeze the environment to export the dependencies, note that this will add the specific commit to your requirements, so it might be a good idea to delete the commit ID from it.
+> ___
+> **Note 2**: Due to the simplicity of this "package", this installation method was preferred over the more traditional [PyPI](https://pypi.org/).
+
 ## Code structure
 
 * ``acsconv``
-  the core implementation of ACS convolution, including the operators, models, and 2D-to-3D/ACS model converters. 
+  the core implementation of ACS convolution, including the operators, models, and 2D-to-3D/ACS model converters.
   * ``operators``: include ACSConv, SoftACSConv and Conv2_5d.
   * ``converters``: include converters which convert 2D models to 3d/ACS/Conv2_5d counterparts.
-  * ``models``: Native ACS models. 
-* ``experiments`` 
+  * ``models``: Native ACS models.
+* ``experiments``
   the scripts to run experiments.
   * ``mylib``: the lib for running the experiments.
   * ``poc``: the scripts to run proof-of-concept experiments.

--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ B) Or install it through `pip` following the command bellow:
 pip install git+git://github.com/M3DV/ACSConv.git#egg=ACSConv
 ```
 
-> **Note 1**: As noted by [David Winterbottom](https://codeinthehole.com/tips/using-pip-and-requirementstxt-to-install-from-the-head-of-a-github-branch/), if you freeze the environment to export the dependencies, note that this will add the specific commit to your requirements, so it might be a good idea to delete the commit ID from it.
-> ___
-> **Note 2**: Due to the simplicity of this "package", this installation method was preferred over the more traditional [PyPI](https://pypi.org/).
-
 ## Code structure
 
 * ``acsconv``

--- a/acsconv/converters/base_converter.py
+++ b/acsconv/converters/base_converter.py
@@ -23,6 +23,10 @@ class BaseConverter(object):
         for child_name, child in module.named_children(): 
             if isinstance(child, nn.Conv2d):
                 arguments = nn.Conv2d.__init__.__code__.co_varnames[1:]
+
+                # cleaning the tuple due to new PyTorch namming schema (or added new variables)
+                arguments = [a for a in arguments if a not in ['kernel_size_', 'stride_', 'padding_', 'dilation_']]
+
                 kwargs = {k: getattr(child, k) for k in arguments}
                 kwargs = self.convert_conv_kwargs(kwargs)
                 setattr(module, child_name, self.__class__.target_conv(**kwargs))

--- a/experimental_requirements.txt
+++ b/experimental_requirements.txt
@@ -1,0 +1,11 @@
+fire==0.4.0
+jupyterlab>=3.0.12
+matplotlib==3.3.4
+pandas==1.1.3
+torch==1.8.0
+torchvision==0.9.0
+tqdm==4.59.0
+scikit-image==0.17.2
+scikit-learn==0.24.1
+scipy==1.5.2
+tensorboardx==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+torch>=1.8.0
+torchvision>=0.9.0

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ def readme():
         content = f.read()
     return content
 
+with open('requirements.txt', 'r') as f:
+    requirements = f.readlines()
 
 setup(
     name='ACSConv',
@@ -18,6 +20,7 @@ setup(
     author_email='jekyll4168@sjtu.edu.cn',
     description='[IEEE JBHI] Reinventing 2D Convolutions for 3D Images',
     long_description=readme(),
+    install_requires=requirements,
     packages=find_packages(),
     zip_safe=True
 )


### PR DESCRIPTION
- Filtering variables `'kernel_size_'`, `'stride_'`, `'padding_'`, `'dilation_'` on `base_converter.py` which caused the program to break (variables probably added on newer versions of PyTorch (tested on 1.8.0))

- Included a `requirements.txt` for easier installation and instructions on how to install this package.